### PR TITLE
bugfix: Number of heads for LM Transformer

### DIFF
--- a/models/transformer_lm.py
+++ b/models/transformer_lm.py
@@ -27,8 +27,9 @@ class TransformerResult(DotDict):
 class TransformerLM(torch.nn.Module):
     def __init__(
         self,
-        n_input_tokens: int,
-        state_size: int = 512,
+        n_input_tokens: int,  # in_vocab_size
+        state_size: int = 512,  # vec_dim
+        n_heads: int = 8, # n_heads
         ff_multiplier: float = 1,
         max_len: int = 5000,
         transformer=Transformer,
@@ -57,6 +58,7 @@ class TransformerLM(torch.nn.Module):
         self.encoder_sos = n_input_tokens + 1 if encoder_sos else None
         self.state_size = state_size
         self.embedding_init = embedding_init
+        self.n_heads = n_heads
         self.ff_multiplier = ff_multiplier
         self.n_input_tokens = n_input_tokens
         self.scale_mode = scale_mode
@@ -89,6 +91,7 @@ class TransformerLM(torch.nn.Module):
 
         self.trafo = transformer(
             d_model=self.state_size,
+            nhead=self.n_heads,
             dim_feedforward=int(self.ff_multiplier * self.state_size),
             **kwargs
         )

--- a/transformer_helpers.py
+++ b/transformer_helpers.py
@@ -13,7 +13,7 @@ from models.transformer_lm import TransformerLM
 def create_lm(in_vocab_size, vec_dim, n_heads, encoder_n_layers) -> torch.nn.Module:
     args = dict(embedding_init="xavier", scale_mode="opennmt")
     return TransformerLM(
-        in_vocab_size, vec_dim, n_heads, num_encoder_layers=encoder_n_layers, **args
+        in_vocab_size, vec_dim, n_heads=n_heads, num_encoder_layers=encoder_n_layers, **args
     )
 
 


### PR DESCRIPTION
I encountered a bug where the number of heads set in the args `args.n_heads` was being mapped to the `self.ff_multiplier` inside of the `TransformerLM` module. 

This applies a fix and validates that n_heads gets passed all the way to `MultiHeadAttentionBase` in `multi_head_attention.py`.